### PR TITLE
initial dark theme support

### DIFF
--- a/content/main.js
+++ b/content/main.js
@@ -128,6 +128,10 @@ const checkFirstTimeReady = () => {
     const timer = setInterval(setNumNewMessages, 5000);
   }
 
+  if($("html.t-dark") != null ){
+    themeType = 'dark'
+  }
+
   let t1 = setInterval(() => {
     if($("div#mailbox").length > 0 || $("div#conversation").length > 0){
 

--- a/content/move_focus.js
+++ b/content/move_focus.js
@@ -1,11 +1,21 @@
 const indicateLeftRight = (side) => {
   if(useCursorKeys){
     if(leftOrRight === "left"){
-      $("div#conversation div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #ffffff"});
-      $("div#mailbox div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #f7e3e3", "transition": ""});
+      if(themeType === "light"){
+        $("div#conversation div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #ffffff"});
+        $("div#mailbox div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #f7e3e3", "transition": ""});
+      } else {
+        $("div#conversation div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #1b1e20"});
+        $("div#mailbox div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #dc818f", "transition": ""});
+      }
     } else {
-      $("div#mailbox div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #ffffff"});
-      $("div#conversation div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #f7e3e3", "transition": ""});
+      if(themeType === "light"){
+        $("div#mailbox div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #ffffff"});
+        $("div#conversation div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #f7e3e3", "transition": ""});
+      } else {
+        $("div#mailbox div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #1b1e20"});
+        $("div#conversation div.v-Toolbar").css({"box-shadow": "inset 0 -5px 0 #dc818f", "transition": ""});
+      }
     }
   }
 }

--- a/content/setup.js
+++ b/content/setup.js
@@ -10,6 +10,7 @@ let alternativeSearch;
 
 let lastUrl = "https://fastmail.com";
 let searchMode = "anywhere";
+let themeType = "light"; // could be "light" or "dark"
 let readingPaneControlPositionTimer = null;
 let focusOnMessage = true;
 let firstTimeReady = false;


### PR DESCRIPTION
A bit disappointed that dark theme was not supported from the start :P Seems like everyone is using it nowadays.

Here is what I've seen:
![Screenshot from 2022-09-09 19-14-28](https://user-images.githubusercontent.com/544377/189376254-918b17b0-4ef7-4510-86b5-b3c313fc35db.png)

That box shadow didn't look right. So I changed it to this:
![fastmail-plus-dark-mode](https://user-images.githubusercontent.com/544377/189391460-9a376760-9212-4a52-9808-2d02c9f7dace.png)

Search bar colors need some tuning too, but I'll address that in other PR's.
