### PR TITLE
WIP: using Firefox , Safari compatible namespace

### DIFF
--- a/background-script.js
+++ b/background-script.js
@@ -1,30 +1,30 @@
 let badgeTimer;
 const asyncFunctionWithAwait = (message, sender, sendResponse) => {
-  const badgeText = chrome.action.getBadgeText({});
+  const badgeText = browser.action.getBadgeText({});
   badgeText.then(current => {
     if(badgeTimer) clearInterval(badgeTimer);
     if(message.type === "string"){
       if(current !== ""){
-        chrome.action.setBadgeText({text: "" });
+        browser.action.setBadgeText({text: "" });
       }
     } else if(message.value == 0){
       if(current !== ""){
-        chrome.action.setBadgeText({text: "" });
+        browser.action.setBadgeText({text: "" });
       }
     } else if(message.value > 0) {
       const messageValue = String(message.value);
       if(current !== messageValue){
-        // chrome.action.setBadgeBackgroundColor({color: "#e84545"});
-        chrome.action.setBadgeText({text: messageValue });
+        // browser.action.setBadgeBackgroundColor({color: "#e84545"});
+        browser.action.setBadgeText({text: messageValue });
       }
     }
     badgeTimer = setInterval(() => {
-      chrome.action.setBadgeText({text: "" });
+      browser.action.setBadgeText({text: "" });
     },6000);
   });
 }
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   asyncFunctionWithAwait(message, sender, sendResponse)
   return true;
 });

--- a/content/alternative_search.js
+++ b/content/alternative_search.js
@@ -1,5 +1,5 @@
 // const $searchToggleLabel = $('<span id="searchToggleLabel" style="margin-right:8px;">Anywhere</span>');
-const searchToggleImage = chrome.runtime.getURL("svg/arrow-repeat.svg");
+const searchToggleImage = browser.runtime.getURL("svg/arrow-repeat.svg");
 const $searchToggle = $('<button id="search-toggle" title="^S" class="v-Button v-Button--subtle v-Button--sizeM has-icon" style="background-color: #c1c5c8; width:50px; padding:0; margin-right:10px; margin-left:10px">'+
                          `<img src="${searchToggleImage}" /></button>`);
 const $searchExecuteButton = $('<button id="searchExecute" style="margin-left: 10px; margin-right: 0; background-color: darkgray; width:50px;" class="v-Button v-Button--cta v-Button--sizeM"><span class="label">Go</span></button>');

--- a/content/main.js
+++ b/content/main.js
@@ -107,13 +107,13 @@ const setNumNewMessages = () => {
   const badge = inbox.find("span.v-MailboxSource-badge").first().text();
   numNewMessages = badge ? parseInt(badge) : 0;
 
-  if (chrome.runtime?.id && regexMail.test(location.href)){
-    chrome.runtime.sendMessage({
+  if (browser.runtime?.id && regexMail.test(location.href)){
+    browser.runtime.sendMessage({
       type: "number",
       value: numNewMessages
     });
   } else {
-    chrome.runtime.sendMessage({
+    browser.runtime.sendMessage({
       type: "string",
       value: ""
     });

--- a/content/reading_pane_control.js
+++ b/content/reading_pane_control.js
@@ -13,7 +13,7 @@ $readingPaneButtons.attr('id', 'readingPaneButtons');
 
 const createImageLabel = (imgPath, key) => {
   return "<span class='label'>" +
-         `<img style='vertical-align:text-top' src='${chrome.runtime.getURL(imgPath)}' />` +
+         `<img style='vertical-align:text-top' src='${browser.runtime.getURL(imgPath)}' />` +
          "</span>";
 }
 

--- a/content/setup.js
+++ b/content/setup.js
@@ -30,7 +30,7 @@ const keys = [
 ]
 
 const getSyncStorage = (keys) => new Promise(resolve => {
-  chrome.storage.local.get(keys, resolve);
+  browser.storage.local.get(keys, resolve);
 });
 
 getSyncStorage().then((vals) => {

--- a/options.js
+++ b/options.js
@@ -1,4 +1,4 @@
-chrome.storage.local.get(["alternativeSearch", "displayNumMessages", "alternativeShortcutKeys", "useCursorKeys"], (val) => {
+browser.storage.local.get(["alternativeSearch", "displayNumMessages", "alternativeShortcutKeys", "useCursorKeys"], (val) => {
   $('[name="alternative-search"]').prop('checked', val.alternativeSearch);
   $('[name="display-num-messages"]').prop('checked', val.displayNumMessages);
   $('[name="alternative-shortcut-keys"]').prop('checked', val.alternativeShortcutKeys);
@@ -7,32 +7,32 @@ chrome.storage.local.get(["alternativeSearch", "displayNumMessages", "alternativ
 
 $("#alternative-search").on("click", () => {
   let alternativeSearch = $('[name="alternative-search"]').prop('checked');
-  chrome.storage.local.set({'alternativeSearch': alternativeSearch}, () => {});
+  browser.storage.local.set({'alternativeSearch': alternativeSearch}, () => {});
 })
 
 $("#display-num-messages").on("click", () => {
   let displayNumMessages = $('[name="display-num-messages"]').prop('checked');
-  chrome.storage.local.set({'displayNumMessages': displayNumMessages}, () => {});
+  browser.storage.local.set({'displayNumMessages': displayNumMessages}, () => {});
 })
 
 $("#alternative-shortcut-keys").on("click", () => {
   let alternativeShortcutKeys = $('[name="alternative-shortcut-keys"]').prop('checked');
-  chrome.storage.local.set({'alternativeShortcutKeys': alternativeShortcutKeys}, () => {});
+  browser.storage.local.set({'alternativeShortcutKeys': alternativeShortcutKeys}, () => {});
 })
 
 $("#use-cusror-keys").on("click", () => {
   let useCursorKeys = $('[name="use-cusror-keys"]').prop('checked');
-  chrome.storage.local.set({'useCursorKeys': useCursorKeys}, () => {});
+  browser.storage.local.set({'useCursorKeys': useCursorKeys}, () => {});
 })
 
 $("#go-to-fastmail").on("click", () => {
-  chrome.tabs.create({ url: "http://www.fastmail.com/" });
+  browser.tabs.create({ url: "http://www.fastmail.com/" });
 })
 
 $("#github-repo").on("click", () => {
-  chrome.tabs.create({ url: "https://github.com/yohasebe/fastmail-plus" });
+  browser.tabs.create({ url: "https://github.com/yohasebe/fastmail-plus" });
 })
 
 $("#sign-up-with-fastmail").on("click", () => {
-  chrome.tabs.create({ url: "https://ref.fm/u27773408" });
+  browser.tabs.create({ url: "https://ref.fm/u27773408" });
 })


### PR DESCRIPTION
According to Mozilla [cross-browser compitability guide](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Build_a_cross_browser_extension#api_namespace):

> 
> There are two API namespaces in use among the main browsers:
> 
>     browser.*, the proposed standard for the extensions API used by Firefox and Safari.
>     chrome.* used by Chrome, Opera, and Edge.
> 
> Firefox also supports the chrome.* namespace for APIs that are compatible with Chrome, primarily to assist with [porting](https://extensionworkshop.com/documentation/develop/porting-a-google-chrome-extension/). However, using the browser.* namespace is preferred. In addition to being the proposed standard, browser.* uses promises—a modern and convenient mechanism for handling asynchronous events.

[manifest 3 migration guide](https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/) also recommends to move to `browser.` namespace:

> Chromium introduces [promise](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview#promises) support to many methods with the goal of eventually supporting promises on all appropriate methods. This will provide for greater compatibility between Firefox and Chrome extensions, given that Firefox already supports promises when using the browser.* namespace.


This is a proposal to rename API namespace to `browser.` to benefit from `promises` and to have more code compitability with other browsers.

