### PR TITLE
Build Firefox extension with manifest v2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,9 @@ task :build do
       `zip -r fastmail-plus-chrome.zip #{components.join(" ")}`
       `rm #{manifest}`
     when /\.v2\.json\z/
-      ;
+      `ln #{m} #{manifest}`
+      `zip -r fastmail-plus-firefox.zip #{components.join(" ")}`
+      `rm #{manifest}`
     end
   end
 end

--- a/manifests/manifest.v2.json
+++ b/manifests/manifest.v2.json
@@ -1,0 +1,53 @@
+{
+    "manifest_version": 2,
+    "name": "Fastmail Plus",
+    "default_locale": "en",
+    "version": "0.2.8.0",
+    "description": "A Firefox extension to make Fastmail web UI more usable and productive",
+    "icons": {
+      "16": "images/fastmail-plus-16.png",
+      "48": "images/fastmail-plus-48.png",
+      "128": "images/fastmail-plus-128.png"
+    },
+    "browser_action": {
+      "default_icon": "images/fastmail-plus-128.png",
+      "default_popup": "options.html"
+    },
+    "background": {
+      "scripts": ["background-script.js"]
+    },
+    "content_scripts": [
+      {
+        "matches": ["https://www.fastmail.com/*"],
+        "js": [
+          "libraries/jquery-3.6.0.min.js",
+          "libraries/jquery-ui.min.js",
+          "content/setup.js",
+          "content/move_focus.js",
+          "content/search_fix.js",
+          "content/alternative_search.js",
+          "content/reading_pane_control.js",
+          "content/extra_shortcuts.js",
+          "content/fold_quote.js",
+          "content/main.js"
+        ],
+        "css": [
+          "libraries/jquery-ui.min.css",
+          "content/main.css"
+        ]
+      }
+    ],
+    "options_ui": {
+      "page": "options.html",
+      "open_in_tab": false
+    },
+    "permissions": ["storage"],
+    "web_accessible_resources": ["svg/*"],
+  
+    "applications": {
+      "gecko": {
+        "id": "firefox@skatkov.com"
+      }
+     }
+  }
+  


### PR DESCRIPTION
Build a firefox webextension with `rake build` command. At this stage, firefox extension will not really work in Firefox due to differences in API.